### PR TITLE
fix: issue allowing strings without "." in the name, including addresses

### DIFF
--- a/ape_ens/converters.py
+++ b/ape_ens/converters.py
@@ -32,6 +32,9 @@ class ENSConversions(ConverterAPI):
         if not isinstance(value, str):
             return False
 
+        elif "." not in value:
+            return False
+
         elif not ENS.is_valid_name(value):
             return False
 

--- a/ape_ens/converters.py
+++ b/ape_ens/converters.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from ape.api import ConverterAPI, Web3Provider
 from ape.exceptions import ProviderError
@@ -12,7 +12,7 @@ class ENSConversions(ConverterAPI):
     """Converts ENS names like `my-name.eth` to `0xAbCd...1234`"""
 
     @cached_property
-    def ens(self) -> Optional[ENS]:
+    def ens(self) -> ENS:
         provider = self.networks.active_provider
 
         if not provider:
@@ -43,5 +43,4 @@ class ENSConversions(ConverterAPI):
             return self.ens.address(value) is not None
 
     def convert(self, value: str) -> AddressType:
-        assert self.ens  # NOTE: Just to make mypy happy
         return self.ens.address(value)

--- a/tests/test_ens.py
+++ b/tests/test_ens.py
@@ -43,5 +43,9 @@ def test_ens_when_not_web3_provider(mocker, mock_config, mock_networks):
 
 def test_is_convertible(converter):
     assert converter.is_convertible("test.eth")
-    assert not converter.is_convertible(23452345)
+
+
+def test_is_not_convertible(converter):
+    assert not converter.is_convertible("test")
     assert not converter.is_convertible("0xe1122aa5533228143C4Ce8fC4642aa33b857B332")
+    assert not converter.is_convertible(23452345)

--- a/tests/test_ens.py
+++ b/tests/test_ens.py
@@ -17,6 +17,12 @@ def mock_config(mocker):
     return mocker.MagicMock(spec=ConfigItem)
 
 
+@pytest.fixture
+def converter(mocker, mock_networks, mock_config):
+    mock_networks.active_provider = mocker.MagicMock(spec=Web3Provider)
+    return ENSConversions(config=mock_config, networks=mock_networks)
+
+
 def test_ens_when_no_provider(mock_config, mock_networks):
     mock_networks.active_provider = None
 
@@ -35,8 +41,7 @@ def test_ens_when_not_web3_provider(mocker, mock_config, mock_networks):
     assert str(err.value) == "Currently, only web3 providers work with this plugin."
 
 
-def test_is_convertible(mocker, mock_config, mock_networks):
-    mock_networks.active_provider = mocker.MagicMock(spec=Web3Provider)
-    converter = ENSConversions(config=mock_config, networks=mock_networks)
+def test_is_convertible(converter):
     assert converter.is_convertible("test.eth")
     assert not converter.is_convertible(23452345)
+    assert not converter.is_convertible("0xe1122aa5533228143C4Ce8fC4642aa33b857B332")


### PR DESCRIPTION
### What I did

fixes: #3 

### How I did it

Filter out values without `.`

### How to verify it

The unit test shows this!

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
