### PR TITLE
chore: use same web3py as ape

### DIFF
--- a/ape_ens/converter.py
+++ b/ape_ens/converter.py
@@ -60,7 +60,11 @@ class ENSConversions(ConverterAPI):
                 if not provider:
                     return False
 
-                address = provider.web3.ens.address(value)
+                ens = provider.web3.ens
+                if not ens:
+                    return False
+
+                address = ens.address(value)
 
                 if address is not None:
                     self.address_cache[value] = address
@@ -80,6 +84,11 @@ class ENSConversions(ConverterAPI):
             raise ValueError(f"Unable to convert ENS value '{value}'.")
 
         # TODO: Switch to using ENS SDK
-        address = provider.web3.ens.address(value)
+        ens = provider.web3.ens
+        if not ens:
+            # Should never get here.
+            raise ValueError(f"Unable to convert ENS value '{value}'.")
+
+        address = ens.address(value)
         self.address_cache[value] = address
         return address

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ setup(
     url="https://github.com/ApeWorX/ape-ens",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.4.0,<0.5.0",
-        "web3>=5.28.0,<6.0",
+        "eth-ape>=0.4.4,<0.5.0",
+        "web3",  # Use same version as eth-ape
         "importlib-metadata ; python_version<'3.8'",
     ],
     python_requires=">=3.7.2,<4",


### PR DESCRIPTION
### What I did

fixes issue when trying to update eth-ape

### How I did it

make web3.py dependency use same version as eth-ape

### How to verify it

can now use eth-ape 0.4.4

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
