### PR TITLE
fix: issue with address lookup fail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,27 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     -   id: check-yaml
 
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
     hooks:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.12.0
+    rev: 24.4.2
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.10.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ extras_require = {
         "ape-polygon",  # For testing against another network named 'mainnet'
     ],
     "lint": [
-        "black>=23.12.0,<24",  # Auto-formatter and linter
-        "mypy>=1.7.1,<2",  # Static type analyzer
+        "black>=24.4.2,<25",  # Auto-formatter and linter
+        "mypy>=1.10.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
-        "flake8>=6.1.0,<7",  # Style linter
+        "flake8>=7.0.0,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
-        "isort>=5.10.1,<6",  # Import sorting linter
+        "isort>=5.13.2,<6",  # Import sorting linter
         "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,3 +108,9 @@ def converter(address, provider_class):
     yield ens
 
     delete_caches()
+
+
+@pytest.fixture
+def mainnet_provider(converter):
+    _ = converter.is_convertible("test.eth")  # Set mainnet_provider
+    return converter.__dict__["mainnet_provider"]

--- a/tests/test_ens.py
+++ b/tests/test_ens.py
@@ -1,12 +1,7 @@
 import ape
-import pytest
+from web3.exceptions import CannotHandleRequest
 
 from tests.conftest import negative_tests
-
-
-@pytest.fixture
-def connection_spy(mocker, converter):
-    return mocker.spy(converter.network_manager, "get_provider_from_choice")
 
 
 def test_is_convertible(converter):
@@ -18,24 +13,38 @@ def test_is_not_convertible(converter, value):
     assert not converter.is_convertible(value)
 
 
+def test_is_not_convertible_when_ens_address_call_fails(converter, mainnet_provider):
+    """
+    Tests against a bug where this would fail in an uncaught way rather
+    than saying ``is_convertible=False``.
+    """
+    mainnet_provider.web3.ens.address.side_effect = CannotHandleRequest
+    # NOTE: Using test2.eth since it should be free from the cache (not used elsewhere)
+    assert not converter.is_convertible("test2.eth")
+
+
 def test_address_cache(converter, address):
     converter.address_cache["test.eth"] = address
     assert converter.convert("test.eth") == address
 
 
-def test_mainnet_fork(converter, connection_spy):
-    with ape.networks.parse_network_choice("ethereum:mainnet-fork:mock-mainnet-fork"):
-        connection_spy.reset_mock()
+def test_mainnet_fork(converter, mocker):
+    get_eco_spy = mocker.spy(converter.network_manager, "get_ecosystem")
+
+    with ape.networks.ethereum.mainnet_fork.use_provider("mock-mainnet-fork"):
+        get_eco_spy.reset_mock()
         converter.convert("test.eth")
 
     # Should not have to reconnect
-    assert not connection_spy.call_count
+    assert not get_eco_spy.call_count
 
 
-def test_other_ecosystem_mainnet(converter, connection_spy):
-    with ape.networks.parse_network_choice("polygon:mainnet:mock-polygon-mainnet"):
-        connection_spy.reset_mock()
+def test_other_ecosystem_mainnet(converter, mocker):
+    get_eco_spy = mocker.spy(converter.network_manager, "get_ecosystem")
+
+    with ape.networks.polygon.mainnet.use_provider("mock-polygon-mainnet"):
+        get_eco_spy.reset_mock()
         converter.convert("test.eth")
 
     # It has to re-connect to Ethereum mainnet temporarily
-    connection_spy.assert_called_once_with("ethereum:mainnet")
+    get_eco_spy.assert_called_once_with("ethereum")


### PR DESCRIPTION
### What I did

fix: issue when address returned a `CannotHandleRequest`, the `.is_convertible` check would fail instead of returning `False`
chore: random plugin cleanup

backstory:
I ran into this bug while running core tests with `ape-ens` installed.

### How I did it

handle `CannotHandleRequest` and return `False` in this case.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
