### PR TITLE
perf: plugin update and load time

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
 
@@ -10,24 +10,24 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+    rev: v1.13.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]
 
 -   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 0.7.18
     hooks:
     -   id: mdformat
         additional_dependencies: [mdformat-gfm, mdformat-frontmatter]

--- a/ape_ens/__init__.py
+++ b/ape_ens/__init__.py
@@ -1,9 +1,19 @@
 from ape import plugins
-from ape.types import AddressType
-
-from .converter import ENSConversions
 
 
 @plugins.register(plugins.ConversionPlugin)
 def converters():
+    from ape.types import AddressType
+
+    from ape_ens.converter import ENSConversions
+
     yield AddressType, ENSConversions
+
+
+def __getattr__(name: str):
+    if name == "ENSConversions":
+        from ape_ens.converter import ENSConversions
+
+        return ENSConversions
+
+    raise AttributeError(name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,8 @@
 [flake8]
 max-line-length = 100
+ignore = E704,W503,PYD002,TC003,TC006
 exclude =
 	venv*
 	docs
 	build
+type-checking-pydantic-enabled = True

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,14 @@ extras_require = {
         "ape-polygon",  # For testing against another network named 'mainnet'
     ],
     "lint": [
-        "black>=24.4.2,<25",  # Auto-formatter and linter
-        "mypy>=1.10.0,<2",  # Static type analyzer
+        "black>=24.10.0,<25",  # Auto-formatter and linter
+        "mypy>=1.13.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
-        "flake8>=7.0.0,<8",  # Style linter
+        "flake8>=7.1.1,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
         "isort>=5.13.2,<6",  # Import sorting linter
-        "mdformat>=0.7.17",  # Auto-formatter for markdown
+        "mdformat>=0.7.18",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
         "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml


### PR DESCRIPTION
### What I did

before:

```
In [1]: %time import ape_ens
CPU times: user 1.13 s, sys: 173 ms, total: 1.3 s
Wall time: 1.53 s
```

after:

```
In [1]: %time import ape_ens
CPU times: user 8.85 ms, sys: 4.13 ms, total: 13 ms
Wall time: 14.2 ms
```

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
